### PR TITLE
Disable browser check on CI for now

### DIFF
--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -54,7 +54,9 @@ jobs:
         python -m pip install .
 
         jupyter labextension list 2>&1 | grep -ie "{{ cookiecutter.labextension_name }}.*OK"
-        python -m jupyterlab.browser_check
+        
+        # TODO: add JupyterLite browser check
+        # python -m jupyterlab.browser_check
 
         check-manifest -v
 
@@ -93,4 +95,6 @@ jobs:
         pip install myextension.tar.gz
         pip install jupyterlab
         jupyter labextension list 2>&1 | grep -ie "{{ cookiecutter.labextension_name }}.*OK"
-        python -m jupyterlab.browser_check --no-chrome-test
+        
+        # TODO: add JupyterLite browser check
+        # python -m jupyterlab.browser_check --no-chrome-test

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -73,6 +73,7 @@
     "liteExtension": true
   },
   "jupyter-releaser": {
+    "skip": ["check-links"],
     "hooks": {
       "before-build-npm": [
         "python -m pip install jupyterlab~=3.1",


### PR DESCRIPTION
The browser check fails because it tries to load the lite extension in JupyterLab, as a regular lab extension.